### PR TITLE
Fixes

### DIFF
--- a/.github/workflows/test-bridge.yml
+++ b/.github/workflows/test-bridge.yml
@@ -76,7 +76,7 @@ jobs:
 
       - name: Run anvil
         run: |
-          anvil &
+          anvil --code-size-limit 300000 &
 
       - uses: taiki-e/install-action@cargo-llvm-cov
       - uses: taiki-e/install-action@nextest

--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,7 @@ VENV_BIN := $(VENV_DIR)/bin
 PYTHON := $(VENV_BIN)/python
 PIP := $(VENV_BIN)/pip
 SOLC_SELECT := $(VENV_BIN)/solc-select
-SOLC := $(VENV_BIN)/solc
+SOLC ?= $(VENV_BIN)/solc
 
 # =============================================================================
 # Virtual Environment Setup
@@ -40,7 +40,7 @@ setup-venv:
 	$(PIP) install solc-select
 	$(SOLC_SELECT) install 0.8.24
 	$(SOLC_SELECT) use 0.8.24
-	$(VENV_BIN)/solc --version
+	$(SOLC) --version
 
 # =============================================================================
 # ASDF Version Manager Setup

--- a/src/setup_scripts/upgrade_l1_bridge.rs
+++ b/src/setup_scripts/upgrade_l1_bridge.rs
@@ -6,6 +6,7 @@ use ethers::prelude::{abigen, Bytes, SignerMiddleware};
 use ethers::providers::{Http, Provider};
 use ethers::signers::{LocalWallet, Signer};
 use ethers::types::{Address, U256};
+use tokio::time::{sleep, Duration};
 
 use crate::ConfigFile;
 
@@ -71,20 +72,25 @@ pub async fn upgrade_l1_bridge(ethereum_bridge_address: Address, config_file: &C
         .send()
         .await?;
     log::debug!("New ETH bridge add_implementation ✅");
+    sleep(Duration::from_secs(20)).await;
     eth_bridge_proxy_client.upgrade_to(new_eth_bridge_client.address(), call_data, false).send().await?;
     log::debug!("New ETH bridge upgrade_to ✅");
+    sleep(Duration::from_secs(20)).await;
     new_eth_bridge_client
         .register_app_role_admin(Address::from_str(&config_file.l1_deployer_address.clone())?)
         .send()
         .await?;
+    sleep(Duration::from_secs(20)).await;
     new_eth_bridge_client
         .register_governance_admin(Address::from_str(&config_file.l1_deployer_address.clone())?)
         .send()
         .await?;
+    sleep(Duration::from_secs(20)).await;
     new_eth_bridge_client
         .register_app_governor(Address::from_str(&config_file.l1_deployer_address.clone())?)
         .send()
         .await?;
+    sleep(Duration::from_secs(20)).await;
     new_eth_bridge_client
         .set_max_total_balance(
             Address::from_str("0x0000000000000000000000000000000000455448").unwrap(),


### PR DESCRIPTION
Include a delay to deploy L1 bridge contracts

Allow setting a different solidity executable to the makefile. This was needed in order to build the docker image for arm64 since the release binaries were not working as expected.
If `SOLC` is not set, then the default value `$(VENV_BIN)/solc` will be used (backward compatible)